### PR TITLE
Reverts the styling collision of speaker card and keynote speaker cards

### DIFF
--- a/src/_includes/components/keynote.liquid
+++ b/src/_includes/components/keynote.liquid
@@ -8,7 +8,7 @@
             </div>
 
             {% for speaker in keynotes %}
-            <div class="col-md-5 mt-5 pb-5 pt-5">
+            <div class="col-md-5 mt-5 pb-5 pt-5 keynote-speaker-card">
                 <div class="speaker-laybox bg-white text-center">
                     <img src="{{ speaker.image }}" class="img-fluid speaker-img w-60" width="240" alt="{{ speaker.name }}">
                     <h3 class="speakerheading-boxed pt-4 text-uppercase">{{ speaker.name }}</h3>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -640,6 +640,11 @@ thead th {
   object-fit: cover;
   aspect-ratio: 1;
 }
+
+.keynote-speaker-card .speaker-laybox img {
+  height: 340px;
+  aspect-ratio: auto;
+}
 .speakerheading-boxed {
   font-size: clamp(1.125rem, 0.8207rem + 1.5217vw, 2rem);
   font-weight: 600;


### PR DESCRIPTION
Making the speaker cards compact changed the styling for keynote speaker cards in the homepage as well because of shared classes. Added more specific  styling for keynote speakers to ensure that the designs of the keynote speaker cards still maintain the original design.

cc @sayanchowdhury @anistark 
